### PR TITLE
build: configure ldflags to enable compilation with go 1.23

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,4 +1,6 @@
 version: 1
+build:
+  ldflags: [ "-checklinkname=0" ]
 validation: sovereign
 accounts: 
 - name: alice


### PR DESCRIPTION
Quote from memsize README:
> NOTE: As of Go 1.23, memsize no longer works because of a restriction added by the
> Go toolchain. The Go 1.23 compiler no longer allows access to runtime symbols via
> go:linkname, which prevents memsize from accessing the Stop-the-World
> functionality of the Go runtime.
>
> If your program depends on memsize, you can disable the restriction when building
> your program:
>
>    go build -ldflags=-checklinkname=0

As build is managed by ignite, the configuration in config.yml was altered to set proper ldflags.