### PR TITLE
Fix Numbering Format in Documentation.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,30 +33,30 @@ As the first rollup kit equipped with Aspects, Artela network aims to **maximize
 
 ## Build the source
 
-1). Set Up Your Go Development Environment<br />
+1) Set Up Your Go Development Environment<br />
 
 Make sure you have set up your [Go](https://go.dev/) development environment.
 
-2). Install ignite-cli<br />
+2) Install ignite-cli<br />
 
 ```sh
 curl https://get.ignite.com/cli@v28.4.0! | bash
 ```
 
-3). Install rollkit-cli <br />
+3) Install rollkit-cli <br />
 
 ```sh
 curl -sSL https://rollkit.dev/install.sh | sh -s v0.13.6
 ```
 
-4). Download the Source Code<br />
+4) Download the Source Code<br />
 Obtain the project source code using the following method:
 
 ```
 git clone https://github.com/artela-network/artela-rollkit.git
 ```
 
-5). Compile<br />
+5) Compile<br />
 Compile the source code and generate the executable using the Go compiler:
 
 ```


### PR DESCRIPTION
This PR updates the numbering format in the documentation from "1)." to "1." (and subsequently for 2 to 5) for consistency and readability.

Changes Made:

Changed the numbering format from "1)." to "1." for all numbered steps in the README or relevant documentation.

Updated steps 1 through 5 to follow the new format:

"1."

"2."

"3."

"4."

"5."



Why:
This change standardizes the format for numbered lists, making the documentation easier to read and consistent with the preferred style.